### PR TITLE
add two api for set path parameter along with tests

### DIFF
--- a/request.go
+++ b/request.go
@@ -112,6 +112,16 @@ func (r Request) Attribute(name string) interface{} {
 	return r.attributes[name]
 }
 
+// SetPathParameter adds or replaces path parameter with the given value.
+func (r *Request) SetPathParameter(key string, val string) {
+	r.pathParameters[key] = val
+}
+
+// SetPathParameters sets all path parameters to the given map.
+func (r *Request) SetPathParameters(pathParameters map[string]string) {
+	r.pathParameters = pathParameters
+}
+
 // SelectedRoutePath root path + route path that matched the request, e.g. /meetings/{id}/attendees
 func (r Request) SelectedRoutePath() string {
 	return r.selectedRoutePath

--- a/request_test.go
+++ b/request_test.go
@@ -153,3 +153,36 @@ func TestSetAttribute(t *testing.T) {
 		t.Fatalf("missing request attribute:%v", there)
 	}
 }
+
+func TestSetPathParameter(t *testing.T) {
+	bodyReader := strings.NewReader("?")
+	httpRequest, _ := http.NewRequest("GET", "/test", bodyReader)
+	request := NewRequest(httpRequest)
+	request.SetPathParameter("go", "there")
+	there := request.PathParameter("go")
+	if there != "there" {
+		t.Fatalf("missing request path parameter:%v", there)
+	}
+}
+
+func TestSetPathParameters(t *testing.T) {
+	bodyReader := strings.NewReader("?")
+	httpRequest, _ := http.NewRequest("GET", "/test", bodyReader)
+	request := NewRequest(httpRequest)
+	request.SetPathParameters(map[string]string {
+		"go": "there",
+		"hello": "world",
+	})
+	len := len(request.PathParameters())
+	there := request.PathParameter("go")
+	world := request.PathParameter("hello")
+	if len != 2 {
+		t.Fatalf("path parameter length error:%v, which should be 2", len)
+	}
+	if world != "world" {
+		t.Fatalf("missing request path parameter:%v", world)
+	}
+	if there != "there" {
+		t.Fatalf("missing request path parameter:%v", there)
+	}
+}


### PR DESCRIPTION
Since struct field pathParameters is private in request.go and anytime we try to new a request, pathParameters will be empty. So we need public api to set path parameters, thus we add these two apis, one for single param, one for mutiple params. Then we can call these apis in other pkgs to set restful request's path parameters, which is really helpful when test and debug.